### PR TITLE
Minor changes

### DIFF
--- a/osu!stream/GameModes/MainMenu/NewsButton.cs
+++ b/osu!stream/GameModes/MainMenu/NewsButton.cs
@@ -44,7 +44,7 @@ namespace osum.GameModes.MainMenu
         {
             HasNews = false;
 
-            GameBase.Instance.ShowWebView(@"https://osustream.com/p/news", "News");
+            GameBase.Instance.ShowWebView(@"https://news.osustream.com/", "News");
 
             GameBase.Config.SetValue("NewsLastRead", GameBase.Config.GetValue("NewsLastRetrieved", string.Empty));
             GameBase.Config.SaveConfig();

--- a/osu!stream/Support/Desktop/GameWindowDesktop.cs
+++ b/osu!stream/Support/Desktop/GameWindowDesktop.cs
@@ -18,9 +18,9 @@ namespace osum.Support.Desktop
 {
     public class GameWindowDesktop : GameWindow
     {
-        /// <summary>Creates a 1024x768 window with the specified title.</summary>
+        /// <summary>Creates a 1280x720 window with the specified title.</summary>
         public GameWindowDesktop()
-            : base(2436, 1125, GraphicsMode.Default, "osu!stream")
+            : base(1280, 720, GraphicsMode.Default, "osu!stream")
         {
             VSync = VSyncMode.On;
             //GameBase.WindowSize = new Size(960,640);


### PR DESCRIPTION
``https://osustream.com/p/news`` redirects to ``https://news.osustream.com``
I am not 100% sure on the window size change, while it does fix the window being out of bounds / window borders being invisible on my 1920x1080 display, I don't have a iPhone X to test if it breaks on that...
![image](https://user-images.githubusercontent.com/23622616/84110193-692da400-a9f2-11ea-9f40-580db8af4303.png)
