### PR TITLE
Remove restore purchases button, since all packs were made free

### DIFF
--- a/osu!stream/GameModes/Store/StoreMode.cs
+++ b/osu!stream/GameModes/Store/StoreMode.cs
@@ -211,7 +211,7 @@ namespace osum.GameModes.Store
                     return;
 
                 AddPack(pp);
-                
+
                 // PackPanel restorePack = new PackPanel(LocalisationManager.GetString(OsuString.RestorePurchases), PackPanel.RESTORE_PACK_ID, false);
                 // AddPack(restorePack);
 

--- a/osu!stream/GameModes/Store/StoreMode.cs
+++ b/osu!stream/GameModes/Store/StoreMode.cs
@@ -211,6 +211,9 @@ namespace osum.GameModes.Store
                     return;
 
                 AddPack(pp);
+                
+                // PackPanel restorePack = new PackPanel(LocalisationManager.GetString(OsuString.RestorePurchases), PackPanel.RESTORE_PACK_ID, false);
+                // AddPack(restorePack);
 
                 GameBase.ShowLoadingOverlay = false;
 

--- a/osu!stream/GameModes/Store/StoreMode.cs
+++ b/osu!stream/GameModes/Store/StoreMode.cs
@@ -212,9 +212,6 @@ namespace osum.GameModes.Store
 
                 AddPack(pp);
 
-                PackPanel restorePack = new PackPanel(LocalisationManager.GetString(OsuString.RestorePurchases), PackPanel.RESTORE_PACK_ID, false);
-                AddPack(restorePack);
-
                 GameBase.ShowLoadingOverlay = false;
 
                 HasNewStoreItems = false;


### PR DESCRIPTION
It should be redundant now, unless apple requires it, which i wouldnt be too surprised if so