### PR TITLE
Fix Compile error on Desktop, Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ While contributions are welcomed I likely won’t have time to review anything t
 - Bringing the `arcade` branch up-to-date and potentially merging changes back into master.
 - Documentation of any kind.
 - Code quality improvements of any kind (as long as they can easily be reviewed and are guaranteed to not change behaviour). Keep individual PRs under 200 lines of change, optimally.
-- Adding full android support (there's a wip branch but it's so outdated I think starting from zero would be easier). Note that this should not degrade the quality of existing code as much as possible, so above tasks may need to come first.
 
 ## Running
 

--- a/osu!stream/Main.cs
+++ b/osu!stream/Main.cs
@@ -1,7 +1,8 @@
 using osum.Audio;
 using osum.Graphics;
-using osum.Support.Android;
+
 #if ANDROID
+using osum.Support.Android;
 using Android.App;
 using Android.OS;
 using Android.Support.V7.App;


### PR DESCRIPTION
Fixes a incredibly small compile error caused by desktop using a using statement that is only available when compiling for android,

also removed a bullet point from the Readme as the Android port done by Beyley and daCyuubi is now complete.

(also speaking of bullet points, im currently planning to potentially write a whole mapping guide on how to get everything set up and how to map for osu!stream so that might soon be coming)