### PR TITLE
✨ Use HttpClient instead of WebClient

### DIFF
--- a/osu!stream/osu!stream_android.csproj
+++ b/osu!stream/osu!stream_android.csproj
@@ -42,9 +42,12 @@
     <BundleAssemblies>false</BundleAssemblies>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AndroidSupportedAbis />
-    <AndroidPackageFormat>aab</AndroidPackageFormat>
+    <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidCreatePackagePerAbi>false</AndroidCreatePackagePerAbi>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <AndroidTlsProvider>
+    </AndroidTlsProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -67,6 +70,9 @@
     <AndroidPackageFormat>aab</AndroidPackageFormat>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidCreatePackagePerAbi>false</AndroidCreatePackagePerAbi>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <AndroidTlsProvider>
+    </AndroidTlsProvider>
   </PropertyGroup>
   <ItemGroup>
     <!--    <Reference Include="Bass.Net.Android">-->

--- a/osu!stream/osu!stream_desktop.csproj
+++ b/osu!stream/osu!stream_desktop.csproj
@@ -9,7 +9,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>osum</RootNamespace>
     <AssemblyName>osu!stream</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -234,6 +234,7 @@
     <Reference Include="OpenTK">
       <HintPath>OpenTK.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Android clients have not been able to load the store since at least May 8th.

Debugging shows:
```
{System.Net.WebException: Error: TrustFailure (Authentication failed, see inner exception.) ---> System.Security.Authentication.AuthenticationException: Authentication failed, see inner exception. ---> Mono.Btls.MonoBtlsException: Ssl error:1000007d:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED
```

There are many threads online related to this issue, especially since Let's Encrypt changed root chains a few years ago. I cannot verify this, but I must assume Cloudflare also changed something on their end when renewing our osu-stream.com certificate (so the issue might be happening since April 22nd).

The solution is "simply" to use Android's TLS implementation rather than the legacy one (Mono's?), however this doesn't appear to be possible when using `WebClient` (I couldn't find any related documentation).

So I rewrote `DataNetRequest` to use `HttpClient` instead of `WebClient`. We lost the upload progress feature, but this doesn't appear to be used anywhere. Also had to bump the desktop project from .NET Framework 3.5 to .NET Framework 4.5.