### PR TITLE
Port features from the mapper branch

### DIFF
--- a/.idea/.idea.osu!stream_desktop/.idea/projectSettingsUpdater.xml
+++ b/.idea/.idea.osu!stream_desktop/.idea/projectSettingsUpdater.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="RiderProjectSettingsUpdater">
-    <option name="vcsConfiguration" value="1" />
+    <option name="singleClickDiffPreview" value="1" />
+    <option name="vcsConfiguration" value="3" />
   </component>
 </project>

--- a/LocalisationUpdater/LocalisationUpdater.csproj
+++ b/LocalisationUpdater/LocalisationUpdater.csproj
@@ -55,6 +55,9 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
+  </ItemGroup> <!-- Needed for old framework versions -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/osu!stream/GameModes/MainMenu/MainMenu.cs
+++ b/osu!stream/GameModes/MainMenu/MainMenu.cs
@@ -164,7 +164,7 @@ namespace osum.GameModes.MainMenu
                 spriteManager.Add(headphones);
 
 #if !DIST
-                headphones.OnClick += delegate
+                if (GameBase.Config.GetValue(@"MapperMode", true))
                 {
                     GameBase.Mapper = true;
                     pText t = new pText("ENABLED MAPPER MODE", 24, new Vector2(0, 30), 1, false, Color4.Red)

--- a/osu!stream/GameModes/Options/Options.cs
+++ b/osu!stream/GameModes/Options/Options.cs
@@ -87,6 +87,10 @@ namespace osum.GameModes.Options
             buttonEasyMode = new pButton(LocalisationManager.GetString(OsuString.DefaultToEasyMode), new Vector2(button_x_offset, vPos), new Vector2(280, 50), Color4.SkyBlue, delegate { DisplayEasyModeDialog(); });
             smd.Add(buttonEasyMode);
 
+            vPos += 70;
+            buttonMapperMode = new pButton("Mapper mode", new Vector2(button_x_offset, vPos), new Vector2(280, 50), Color4.SkyBlue, delegate { DisplayMapperModeDialog(); });
+            smd.Add(buttonMapperMode);
+            
             vPos += 60;
 
             text = new pText(LocalisationManager.GetString(OsuString.Audio), 36, new Vector2(header_x_offset, vPos), 1, true, Color4.White) { Bold = true, TextShadow = true };
@@ -273,6 +277,7 @@ namespace osum.GameModes.Options
         private pButton buttonFingerGuides;
         private pButton buttonEasyMode;
         private pSprite s_Header;
+        private pButton buttonMapperMode;
 
         internal static void DisplayFingerGuideDialog()
         {
@@ -291,6 +296,7 @@ namespace osum.GameModes.Options
         {
             buttonEasyMode.SetStatus(GameBase.Config.GetValue(@"EasyMode", false));
             buttonFingerGuides.SetStatus(GameBase.Config.GetValue(@"GuideFingers", false));
+            buttonMapperMode.SetStatus(GameBase.Config.GetValue(@"MapperMode", false));
         }
 
         internal static void DisplayEasyModeDialog()
@@ -303,6 +309,31 @@ namespace osum.GameModes.Options
 
                     if (Director.CurrentMode is Options o) o.UpdateButtons();
                 });
+            GameBase.Notify(notification);
+        }
+        internal static void DisplayMapperModeDialog()
+        {
+            bool initialValue = GameBase.Config.GetValue(@"MapperMode", false);
+            Notification notification = new Notification(
+                "Mapper Mode",
+                "Enable Mapper mode? This will enable features specifically for mapping purposes and may not be suitable for normal gameplay.",
+                NotificationStyle.YesNo,
+                delegate(bool yes)
+                {
+                    GameBase.Config.SetValue(@"MapperMode", yes);
+
+                    if (Director.CurrentMode is Options o) o.UpdateButtons();
+                    
+                    if (!initialValue && yes)
+                        GameBase.Notify(
+                            new Notification(
+                                "Restart required",
+                                "You will need to restart osu!stream for this change to take effect.",
+                                NotificationStyle.Okay,
+                                delegate (bool resp) { Environment.Exit(0); })
+                        );
+                });
+
             GameBase.Notify(notification);
         }
 

--- a/osu!stream/GameModes/SongSelect/SongSelect.cs
+++ b/osu!stream/GameModes/SongSelect/SongSelect.cs
@@ -1,6 +1,8 @@
+
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using OpenTK;
 using OpenTK.Graphics;
 using osum.Audio;
@@ -164,10 +166,23 @@ namespace osum.GameModes.SongSelect
             BeatmapDatabase.Initialize();
 
 #if !DIST
-            if (GameBase.Mapper)
+            if (BeatmapDatabase.BeatmapInfo.Count > 0) // Just check if the database has something
             {
-                //desktop/mapper builds.
-                recursiveBeatmaps(BeatmapPath);
+                
+                // Check if the database matches the directory
+                string[] directoryBeatmaps = Directory.GetFiles(BeatmapPath, "*.osz2");
+                string[] databaseBeatmaps = BeatmapDatabase.BeatmapInfo.Select(
+                    info =>
+                    {
+                        return info.GetBeatmap().ContainerFilename;
+                    })
+                    .ToArray();
+
+                if (!(directoryBeatmaps == databaseBeatmaps))
+                {
+                    recursiveBeatmaps(BeatmapPath);
+                    Console.WriteLine("Changes detected, refreshing list.");
+                }
             }
             else
 #endif

--- a/osu!stream/Info.plist
+++ b/osu!stream/Info.plist
@@ -19,8 +19,8 @@
 	<string>YES</string>
 	<key>UIStatusBarHidden</key>
 	<true/>
-    <key>CADisableMinimumFrameDurationOnPhone</key>
-    <true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
@@ -76,5 +76,7 @@
 	<string>2020.226.0</string>
 	<key>CFBundleShortVersionString</key>
 	<string>2020</string>
+	<key>UIFileSharingEnabled</key>
+	<string>YES</string>
 </dict>
 </plist>

--- a/osu!stream/Localisation/LocalisationManager.cs
+++ b/osu!stream/Localisation/LocalisationManager.cs
@@ -207,6 +207,7 @@ namespace osum.Localisation
         TwitterSuccess,
         TwitterSuccessDetails,
         UniversalOffset,
-        UniversalOffsetDetails
+        UniversalOffsetDetails,
+        EnableMapper
     }
 }

--- a/osu!stream/osu!stream_desktop.csproj
+++ b/osu!stream/osu!stream_desktop.csproj
@@ -497,6 +497,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
+  </ItemGroup> <!-- Needed for old framework versions -->
   <PropertyGroup>
     <PostBuildEvent>
     </PostBuildEvent>


### PR DESCRIPTION
It should allow users to be able to use mapper, regardless of platform. Unlike previous method, which requires `OnClick` delegate, that implies it's desktop exclusive, it's available through the options
![{717A2925-5657-447B-9AE3-DA10AB5AB666}](https://github.com/user-attachments/assets/63a12095-8f39-4022-ba31-f30055c82d36)
![{970ECEA4-E644-49BE-9BED-358F9DE2FA2D}](https://github.com/user-attachments/assets/82765adc-0fbd-499a-b22d-a4165d05d4cc)

although a restart may be required just in case, in which I added an extra dialog once it's enabled. 
![{8E64F34E-D8E6-4903-857B-030CE320F2F1}](https://github.com/user-attachments/assets/ce021936-db3c-485d-b228-8828669366e2)


The only thing it lacked is localisation.

On the internal end, the game will refresh the beatmap list if there's changes in the Beatmap directory, regardless of mapper mode.

https://github.com/user-attachments/assets/615e557c-459b-4239-ad71-de51b8c9b31e



There's not really a performance hit, as far as I've seen.

Also, the iTunes file sharing is re-enabled to allow map sideloading in iOS platforms, as there's not really a reason to not allow it, afaik. Although, I don't have the footage for it as I don't have Apple hardwares to test on