### PR TITLE
Handle null if Sprites can't load in time

### DIFF
--- a/osu!stream/GameModes/SongSelect/SongSelect.cs
+++ b/osu!stream/GameModes/SongSelect/SongSelect.cs
@@ -506,12 +506,16 @@ namespace osum.GameModes.SongSelect
                                                 if (!AudioEngine.Music.IsElapsing)
                                                     playFromPreview();
 
-                                                SelectedPanelHoverGlow.Alpha = 1;
-                                                SelectedPanelHoverGlow.Colour = Color4.White;
-                                                SelectedPanelHoverGlow.FadeOut(500, 0.8f);
-                                                SelectedPanelHoverGlow.Transformations[0].Looping = true;
-                                                SelectedPanelHoverGlowLockedIn = SelectedPanelHoverGlow;
-                                                SelectedPanelHoverGlow = null;
+                                                if (SelectedPanelHoverGlow != null)
+                                                {
+                                                    SelectedPanelHoverGlow.Alpha = 1;
+                                                    SelectedPanelHoverGlow.Colour = Color4.White;
+                                                    SelectedPanelHoverGlow.FadeOut(500, 0.8f);
+                                                    SelectedPanelHoverGlow.Transformations[0].Looping = true;
+                                                    SelectedPanelHoverGlowLockedIn = SelectedPanelHoverGlow;
+                                                    SelectedPanelHoverGlow = null;
+                                                }
+                                                
                                                 PreviewingPanel = panel;
                                                 PreviewingPanel.Add(SelectedPanelHoverGlowLockedIn);
                                             }

--- a/osu!stream/Graphics/Sprites/pSpriteCollection.cs
+++ b/osu!stream/Graphics/Sprites/pSpriteCollection.cs
@@ -49,7 +49,11 @@ namespace osum.Graphics.Sprites
         internal void MoveTo(Vector2 location, int duration)
         {
             //todo: this is horribly inefficient.
-            Sprites.ForEach(s => s.MoveTo(location, duration, EasingTypes.In));
+            Sprites.ForEach(s =>
+            {
+                if (s == null) return;
+                s.MoveTo(location, duration, EasingTypes.In);
+            });
         }
     }
 }


### PR DESCRIPTION
When you click Play > quickly click to any song then back to main menu, the game will crash because null object.

https://github.com/user-attachments/assets/6330d968-3623-4d23-89b9-e738b8e63aa3
